### PR TITLE
refactor: use default import for adm-zip

### DIFF
--- a/lib/process-sat-files.ts
+++ b/lib/process-sat-files.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs"
 import * as path from "path"
-import * as AdmZip from "adm-zip"
+import AdmZip from "adm-zip"
 import { DOMParser } from "@xmldom/xmldom"
 import { processCFDI } from "@/lib/cfdi-processor"
 


### PR DESCRIPTION
## Summary
- replace AdmZip namespace import with default import

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Could not find a declaration file for module 'adm-zip', along with other existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68929d5a41b4832cb4428df2af67c50d