### PR TITLE
Propagar RFC del usuario al procesar CFDI

### DIFF
--- a/app/api/process-cfdi/route.ts
+++ b/app/api/process-cfdi/route.ts
@@ -6,6 +6,7 @@ export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
     const files = formData.getAll("files") as File[]
+    const rfc = (formData.get("rfc") as string | null) || ""
 
     if (!files || files.length === 0) {
       return NextResponse.json({ message: "No se proporcionaron archivos" }, { status: 400 })
@@ -33,7 +34,7 @@ export async function POST(request: NextRequest) {
         }
 
         // Procesar el documento XML
-        const cfdiData = processCFDI(xmlDoc)
+        const cfdiData = processCFDI(xmlDoc, rfc)
         if (cfdiData) {
           results.push(cfdiData)
           logs.push(`Archivo ${file.name} procesado correctamente como ${cfdiData.TIPO_DOCUMENTO}`)

--- a/components/file-uploader.tsx
+++ b/components/file-uploader.tsx
@@ -16,6 +16,8 @@ import { Badge } from "@/components/ui/badge"
 import { ExportColumnsDialog } from "@/components/export-columns-dialog"
 import { useToast } from "@/hooks/use-toast"
 
+const USER_RFC = process.env.NEXT_PUBLIC_RFC || ""
+
 // Crear contexto para compartir datos procesados
 export const ProcessedDataContext = createContext<{
   processedData: any[]
@@ -128,7 +130,7 @@ export function FileUploader() {
     setShowTable(false)
 
     try {
-      const data = await processFiles(files, (currentProgress) => {
+      const data = await processFiles(files, USER_RFC, (currentProgress) => {
         setProgress(currentProgress)
       })
 

--- a/lib/cfdi-processor.ts
+++ b/lib/cfdi-processor.ts
@@ -112,7 +112,7 @@ interface TrasladoDRData {
 }
 
 // Modificar la función clasificarXML para identificar correctamente los complementos de pago emitidos y recibidos
-function clasificarXML(xmlDoc: Document, rfcReceptor: string): TipoDocumento {
+function clasificarXML(xmlDoc: Document, rfcReceptor?: string): TipoDocumento {
   try {
     const comprobante = xmlDoc.getElementsByTagName("cfdi:Comprobante")[0]
     if (!comprobante) return "Desconocido"
@@ -124,6 +124,10 @@ function clasificarXML(xmlDoc: Document, rfcReceptor: string): TipoDocumento {
     const pagosNode10 = xmlDoc.getElementsByTagNameNS("http://www.sat.gob.mx/Pagos", "Pagos")[0]
 
     if (pagosNode20 || pagosNode10 || tipoComprobante === "P") {
+      if (!rfcReceptor) {
+        return "ComplementoPagoRecibido"
+      }
+
       // Obtener el RFC del emisor y receptor del XML
       const emisor = xmlDoc.getElementsByTagName("cfdi:Emisor")[0]
       const receptor = xmlDoc.getElementsByTagName("cfdi:Receptor")[0]
@@ -144,6 +148,10 @@ function clasificarXML(xmlDoc: Document, rfcReceptor: string): TipoDocumento {
 
       // Si no podemos determinar, asumimos que es un complemento de pago recibido
       return "ComplementoPagoRecibido"
+    }
+
+    if (!rfcReceptor) {
+      return "Desconocido"
     }
 
     // Obtener el RFC del receptor del XML
@@ -170,7 +178,7 @@ function clasificarXML(xmlDoc: Document, rfcReceptor: string): TipoDocumento {
 }
 
 // Modificar la función processCFDI para incluir el RFC del receptor y soportar múltiples versiones
-export function processCFDI(xmlDoc: Document, rfcReceptor = "GOGR810728TV5"): CFDIData | null {
+export function processCFDI(xmlDoc: Document, rfcReceptor: string): CFDIData | null {
   try {
     // Verificar que sea un CFDI válido (aceptar 3.3 y 4.0)
     const comprobante = xmlDoc.getElementsByTagName("cfdi:Comprobante")[0]

--- a/lib/process-files.ts
+++ b/lib/process-files.ts
@@ -1,5 +1,10 @@
-export async function processFiles(files: File[], progressCallback: (progress: number) => void): Promise<any[]> {
+export async function processFiles(
+  files: File[],
+  rfc: string,
+  progressCallback: (progress: number) => void,
+): Promise<any[]> {
   const formData = new FormData()
+  formData.append("rfc", rfc)
 
   files.forEach((file, index) => {
     formData.append(`files`, file)

--- a/lib/process-sat-files.ts
+++ b/lib/process-sat-files.ts
@@ -7,9 +7,10 @@ import { processCFDI } from "@/lib/cfdi-processor"
 /**
  * Procesa un archivo ZIP descargado del SAT
  * @param zipBuffer Buffer con el contenido del archivo ZIP
+ * @param rfcReceptor RFC del receptor (usuario)
  * @returns Array con los datos procesados de los CFDI
  */
-export async function processSATZipFile(zipBuffer: Buffer): Promise<any[]> {
+export async function processSATZipFile(zipBuffer: Buffer, rfcReceptor: string): Promise<any[]> {
   try {
     // Crear un objeto AdmZip con el buffer del archivo
     const zip = new AdmZip(zipBuffer)
@@ -29,7 +30,7 @@ export async function processSATZipFile(zipBuffer: Buffer): Promise<any[]> {
         const xmlDoc = parser.parseFromString(xmlContent, "text/xml")
 
         // Procesar el CFDI
-        const cfdiData = processCFDI(xmlDoc)
+        const cfdiData = processCFDI(xmlDoc, rfcReceptor)
         if (cfdiData) {
           results.push(cfdiData)
         }


### PR DESCRIPTION
## Summary
- remove default RFC from `processCFDI` and allow `clasificarXML` to handle missing RFCs
- pass the user's RFC through file upload API and SAT ZIP processing
- wire file uploader to supply RFC from environment

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Interactive ESLint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_68929d5ad2c0832c9a0dafd246729bfb